### PR TITLE
Add PyTest + Hypothesis test to reproduce issue #14

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,4 @@
 [wheel]
 universal = 1
+[aliases]
+test=pytest

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,6 @@ setup(name='tripl',
               'tripl = tripl.cli:main',
           ]
       },
-      #test_suite='tripl.test.suite',
-      #tests_require=['mock>=1.0.1']
+      setup_requires=["pytest-runner"],
+      tests_require=["pytest", "hypothesis"],
       )

--- a/tests/test_tripl.py
+++ b/tests/test_tripl.py
@@ -1,0 +1,27 @@
+from pytest import fixture
+from hypothesis import given
+from hypothesis.strategies import builds, text, lists
+
+from tripl import tripl
+
+
+def cft_cons(name):
+    return tripl.entity_cons('cft.type:' + name, 'cft.' + name)
+
+
+make_subject = cft_cons('subject')
+
+schema = {
+    'cft.seq:timepoint': {'db:valueType': 'db.type:ref',
+                          'db:cardinality': 'db.cardinality:many'},
+    'cft.seq:subject': {'db:valueType': 'db.type:ref'}}
+
+
+@fixture
+def triple_store():
+    return tripl.TripleStore(schema=schema, default_cardinality='db.cardinality:one')
+
+
+@given(lists(builds(make_subject, id=text())))
+def test_issue14(triple_store, subjects):
+    triple_store.assert_facts(subjects, id_attrs=['cft.subject:id'])


### PR DESCRIPTION
Hypothesis found that issue #14 can be reproduced by asserting the existence of a single subject with a non-empty ID on an empty TripleStore:
```
---------------------------------- Hypothesis ----------------------------------
Falsifying example: test_issue14(triple_store=<tripl.tripl.TripleStore at 0x7f73df0c6910>, subjects=[{'cft.subject:id': u'', 'cft:type': 'cft.type:subject'}])
```

* https://docs.pytest.org/en/latest/
* https://hypothesis.readthedocs.io/en/latest/