### PR TITLE
Python 3 compatibility

### DIFF
--- a/tripl/tripl.py
+++ b/tripl/tripl.py
@@ -21,6 +21,7 @@ import copy
 import warnings
 import time
 import functools
+import sys
 
 
 # Util
@@ -34,7 +35,7 @@ def log(name, value):
 
 def some(xs, default=None):
     """return some thing from the set, or None if nothing"""
-    if isinstance(xs, (str, unicode, int, float, bool, dict, Entity, uuid.UUID)):
+    if isinstance(xs, SUPPORTED_TYPES):
         return xs
     else:
         try:
@@ -749,3 +750,13 @@ def namespaced(namespace, **avs):
     """Return a constructor function for creating namespaced entities"""
     avs = dict(((namespace + ':' + k if ':' not in k else k), v) for k, v in avs.items())
     return avs
+
+
+# Constants
+# ---------
+SUPPORTED_TYPES = (str, bytes, int, float, bool, dict, Entity, uuid.UUID)
+try:
+    # In Python 2 `str = bytes` and an additional `unicode` type is used for strings:
+    SUPPORTED_TYPES += (unicode,)
+except NameError:
+    pass


### PR DESCRIPTION
This makes `pytest` pass with Python 3.7.5.

cf. https://docs.python.org/3/howto/pyporting.html#text-versus-binary-data

Obsoletes: #28